### PR TITLE
[fix]: openai-compatible api model name in [litellm_adapter]

### DIFF
--- a/backend/app/services/llm/adapters/litellm_adapter.py
+++ b/backend/app/services/llm/adapters/litellm_adapter.py
@@ -61,10 +61,6 @@ class LiteLLMAdapter(BaseLLMAdapter):
         provider = self.config.provider
         model = self.config.model
 
-        # 对于使用 OpenAI 兼容模式的提供商，直接使用模型名
-        if provider in self.CUSTOM_BASE_URL_PROVIDERS:
-            return model
-
         # 对于原生支持的提供商，添加前缀
         prefix = self.PROVIDER_PREFIX_MAP.get(provider, "openai")
         


### PR DESCRIPTION
### **User description**
#47 This may fix
<img width="1894" height="972" alt="image" src="https://github.com/user-attachments/assets/cbaa3cde-3c6b-424d-9c0d-6bafc4477e9e" />


___

### **PR Type**
Bug fix


___

### **Description**
- Remove incorrect early return for OpenAI-compatible API providers

- Ensure all providers use consistent prefix mapping logic

- Fix model name handling in LiteLLM adapter


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Provider Config"] --> B["Get LiteLLM Model Name"]
  B --> C["Apply Provider Prefix"]
  C --> D["Return Formatted Model Name"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>litellm_adapter.py</strong><dd><code>Remove incorrect provider-specific early return logic</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

backend/app/services/llm/adapters/litellm_adapter.py

<ul><li>Removed conditional early return for <code>CUSTOM_BASE_URL_PROVIDERS</code><br> <li> Ensures all providers follow consistent prefix mapping logic<br> <li> Fixes model name formatting for OpenAI-compatible API providers</ul>


</details>


  </td>
  <td><a href="https://github.com/lintsinghua/XCodeReviewer/pull/52/files#diff-9cd0d22389b22125229f4a4ca471173ff939402e5ae849599c4f30020e7b5c96">+0/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

