### PR TITLE
fix: add openssh-client for git repo test

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -84,6 +84,7 @@ RUN apt-get update && \
         libpq5 \
         curl \
         git \
+        openssh-client \
         libpango-1.0-0 \
         libpangoft2-1.0-0 \
         libpangocairo-1.0-0 \


### PR DESCRIPTION
### **User description**
修复测试测试git ssh连通性时缺少ssh命令的问题，需要用到ssh测试连通性


___

### **PR Type**
Bug fix


___

### **Description**
- Add `openssh-client` dependency to Docker image

- Enables SSH connectivity testing for Git repositories

- Resolves missing SSH command in test environment


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Docker Build"] -- "missing SSH" --> B["Git SSH Test Fails"]
  C["Add openssh-client"] -- "provides ssh command" --> D["Git SSH Test Works"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Dockerfile</strong><dd><code>Add openssh-client to Docker dependencies</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

backend/Dockerfile

<ul><li>Added <code>openssh-client</code> package to apt-get install dependencies<br> <li> Placed between <code>git</code> and <code>libpango-1.0-0</code> packages<br> <li> Enables SSH command availability in Docker container for Git SSH <br>connectivity tests</ul>


</details>


  </td>
  <td><a href="https://github.com/lintsinghua/DeepAudit/pull/148/files#diff-fed51f49a9f26cb93cc870efdc9419d425b9422354ae41bb651c3333c8bff486">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

