### PR TITLE
fix: replace 20 bare except clauses with except Exception

### DIFF
--- a/backend/app/api/v1/endpoints/prompts.py
+++ b/backend/app/api/v1/endpoints/prompts.py
@@ -72,7 +72,7 @@ async def list_prompt_templates(
         if t.variables:
             try:
                 variables = json.loads(t.variables)
-            except:
+            except Exception:
                 pass
         
         items.append(PromptTemplateResponse(
@@ -118,7 +118,7 @@ async def get_prompt_template(
     if template.variables:
         try:
             variables = json.loads(template.variables)
-        except:
+        except Exception:
             pass
     
     return PromptTemplateResponse(
@@ -224,7 +224,7 @@ async def update_prompt_template(
     if template.variables:
         try:
             variables = json.loads(template.variables)
-        except:
+        except Exception:
             pass
     
     return PromptTemplateResponse(

--- a/backend/app/api/v1/endpoints/rules.py
+++ b/backend/app/api/v1/endpoints/rules.py
@@ -86,7 +86,7 @@ async def list_rule_sets(
         if rs.severity_weights:
             try:
                 severity_weights = json.loads(rs.severity_weights)
-            except:
+            except Exception:
                 pass
         
         rules = [
@@ -155,7 +155,7 @@ async def get_rule_set(
     if rule_set.severity_weights:
         try:
             severity_weights = json.loads(rule_set.severity_weights)
-        except:
+        except Exception:
             pass
     
     rules = [
@@ -323,7 +323,7 @@ async def update_rule_set(
     if rule_set.severity_weights:
         try:
             severity_weights = json.loads(rule_set.severity_weights)
-        except:
+        except Exception:
             pass
     
     rules = [
@@ -417,7 +417,7 @@ async def export_rule_set(
     if rule_set.severity_weights:
         try:
             severity_weights = json.loads(rule_set.severity_weights)
-        except:
+        except Exception:
             pass
     
     export_data = {

--- a/backend/app/api/v1/endpoints/scan.py
+++ b/backend/app/api/v1/endpoints/scan.py
@@ -90,7 +90,7 @@ async def process_zip_task(task_id: str, file_path: str, db_session_factory, use
                                     "path": rel_path,
                                     "content": content
                                 })
-                        except:
+                        except Exception:
                             pass
 
             # 获取分析配置（优先使用用户配置）

--- a/backend/app/services/agent/knowledge/vulnerabilities/ssrf.py
+++ b/backend/app/services/agent/knowledge/vulnerabilities/ssrf.py
@@ -107,7 +107,7 @@ def is_safe_url(url):
             return False
             
         return True
-    except:
+    except Exception:
         return False
 
 # 使用

--- a/backend/app/services/agent/tools/external_tools.py
+++ b/backend/app/services/agent/tools/external_tools.py
@@ -859,7 +859,7 @@ class SafetyTool(AgentTool):
                 else:
                      return ToolResult(success=True, data=f"Safety 输出:\n{stdout[:1000]}")
 
-            except:
+            except Exception:
                 return ToolResult(success=True, data=f"Safety 输出解析失败:\n{stdout[:1000]}")
             
             vulnerabilities = results if isinstance(results, list) else results.get("vulnerabilities", [])
@@ -986,7 +986,7 @@ class TruffleHogTool(AgentTool):
                 if line.strip():
                     try:
                         findings.append(json.loads(line))
-                    except:
+                    except Exception:
                         pass
             
             if not findings:
@@ -1097,7 +1097,7 @@ Google 开源的漏洞扫描工具。
             
             try:
                 results = json.loads(stdout)
-            except:
+            except Exception:
                 if "no package sources found" in stdout.lower():
                     return ToolResult(success=True, data="OSV-Scanner: 未找到可扫描的包文件")
                 return ToolResult(success=True, data=f"OSV-Scanner 输出:\n{stdout[:1000]}")

--- a/backend/app/services/agent/tools/kunlun_tool.py
+++ b/backend/app/services/agent/tools/kunlun_tool.py
@@ -329,7 +329,7 @@ Kunlun-M 是一款专注于代码安全审计的工具，特别擅长 PHP 和 Ja
             # 清理临时文件
             try:
                 os.unlink(output_file)
-            except:
+            except Exception:
                 pass
 
             if not findings:
@@ -399,7 +399,7 @@ Kunlun-M 是一款专注于代码安全审计的工具，特别擅长 PHP 和 Ja
                 if json_start >= 0 and json_end > json_start:
                     json_str = stdout[json_start:json_end]
                     findings = json.loads(json_str)
-            except:
+            except Exception:
                 pass
 
             # 尝试解析表格格式输出
@@ -429,7 +429,7 @@ Kunlun-M 是一款专注于代码安全审计的工具，特别擅长 PHP 和 Ja
                             "analysis": parts[7] if len(parts) > 7 else "",
                         }
                         findings.append(finding)
-                    except:
+                    except Exception:
                         pass
 
         return findings

--- a/backend/app/services/agent/tools/sandbox_language.py
+++ b/backend/app/services/agent/tools/sandbox_language.py
@@ -308,7 +308,7 @@ class MockMultiDict(dict):
         if type and value is not None:
             try:
                 return type(value)
-            except:
+            except Exception:
                 return default
         return value
     def getlist(self, key):

--- a/backend/app/services/git_ssh_service.py
+++ b/backend/app/services/git_ssh_service.py
@@ -155,7 +155,7 @@ def set_secure_file_permissions(file_path: str):
             # 尝试使用os.chmod作为后备方案
             try:
                 os.chmod(file_path, 0o600)
-            except:
+            except Exception:
                 pass
     else:
         # Unix/Linux/Mac系统

--- a/backend/app/services/llm/adapters/litellm_adapter.py
+++ b/backend/app/services/llm/adapters/litellm_adapter.py
@@ -130,7 +130,7 @@ class LiteLLMAdapter(BaseLLMAdapter):
                     code = err.get('code', '')
                     message = err.get('message', '')
                     return f"[{code}] {message}" if code else message
-            except:
+            except Exception:
                 pass
 
         # 尝试提取 message 字段

--- a/backend/app/services/rag/retriever.py
+++ b/backend/app/services/rag/retriever.py
@@ -300,7 +300,7 @@ class CodeRetriever:
                 try:
                     import json
                     security_indicators = json.loads(security_indicators)
-                except:
+                except Exception:
                     security_indicators = []
             
             result = RetrievalResult(

--- a/backend/app/services/scanner.py
+++ b/backend/app/services/scanner.py
@@ -340,7 +340,7 @@ async def scan_repo_task(task_id: str, db_session_factory, user_config: dict = N
             if task.exclude_patterns:
                 try:
                     task_exclude_patterns = json_module.loads(task.exclude_patterns)
-                except:
+                except Exception:
                     pass
 
             print(f"🚀 开始扫描仓库: {repo_url}, 分支: {branch}, 类型: {repo_type}, 来源: {source_type}")


### PR DESCRIPTION
## What
Replace 20 bare `except:` clauses with `except Exception:`.

## Why
Bare `except:` catches `BaseException`, including `KeyboardInterrupt` and `SystemExit`, which can prevent clean process shutdown and mask critical errors. Using `except Exception:` catches all application-level errors while allowing system-level exceptions to propagate correctly.