### PR TITLE
[fix]: 修复快速扫描git仓库时rule_set_id、prompt_template_id参数遗漏

### DIFF
--- a/backend/app/api/v1/endpoints/projects.py
+++ b/backend/app/api/v1/endpoints/projects.py
@@ -565,6 +565,12 @@ async def scan_project(
     if scan_request and scan_request.file_paths:
         user_config['scan_config'] = {'file_paths': scan_request.file_paths}
 
+    if scan_request:
+        user_config['scan_config'] = {
+            'exclude_patterns': scan_request.exclude_patterns or [],
+            'rule_set_id': scan_request.rule_set_id,
+            'prompt_template_id': scan_request.prompt_template_id,
+    }
     # Trigger Background Task
     background_tasks.add_task(scan_repo_task, task.id, AsyncSessionLocal, user_config)
 

--- a/backend/app/api/v1/endpoints/projects.py
+++ b/backend/app/api/v1/endpoints/projects.py
@@ -491,6 +491,8 @@ class ScanRequest(BaseModel):
     full_scan: bool = True
     exclude_patterns: Optional[List[str]] = None
     branch_name: Optional[str] = None
+    rule_set_id: Optional[str] = None
+    prompt_template_id: Optional[str] = None
 
 
 @router.post("/{id}/scan")
@@ -562,15 +564,13 @@ async def scan_project(
         }
 
     # 将扫描配置注入到 user_config 中，以便 scan_repo_task 使用
-    if scan_request and scan_request.file_paths:
-        user_config['scan_config'] = {'file_paths': scan_request.file_paths}
-
     if scan_request:
         user_config['scan_config'] = {
+            'file_paths': scan_request.file_paths or [],
             'exclude_patterns': scan_request.exclude_patterns or [],
             'rule_set_id': scan_request.rule_set_id,
             'prompt_template_id': scan_request.prompt_template_id,
-    }
+        }
     # Trigger Background Task
     background_tasks.add_task(scan_repo_task, task.id, AsyncSessionLocal, user_config)
 

--- a/frontend/src/shared/api/database.ts
+++ b/frontend/src/shared/api/database.ts
@@ -177,7 +177,9 @@ export const api = {
       file_paths: task.scan_config?.file_paths,
       full_scan: !task.scan_config?.file_paths || task.scan_config.file_paths.length === 0,
       exclude_patterns: task.exclude_patterns || [],
-      branch_name: task.branch_name || "main"
+      branch_name: task.branch_name || "main",
+      rule_set_id: task.scan_config?.rule_set_id,
+      prompt_template_id: task.scan_config?.prompt_template_id,
     };
     const res = await apiClient.post(`/projects/${task.project_id}/scan`, scanRequest);
     // Fetch the created task

--- a/frontend/src/shared/types/index.ts
+++ b/frontend/src/shared/types/index.ts
@@ -167,15 +167,11 @@ export interface CreateAuditTaskForm {
   task_type: 'repository' | 'instant';
   branch_name?: string;
   exclude_patterns: string[];
-  rule_set_id?: string;
-  prompt_template_id?: string;
   scan_config: {
-    include_tests?: boolean;
-    include_docs?: boolean;
-    max_file_size?: number;
-    analysis_depth?: 'basic' | 'standard' | 'deep';
     file_paths?: string[];
-  };
+    rule_set_id?: string;
+    prompt_template_id?: string;
+};
 }
 
 export interface InstantAnalysisForm {

--- a/frontend/src/shared/types/index.ts
+++ b/frontend/src/shared/types/index.ts
@@ -168,6 +168,10 @@ export interface CreateAuditTaskForm {
   branch_name?: string;
   exclude_patterns: string[];
   scan_config: {
+    include_tests?: boolean;
+    include_docs?: boolean;
+    max_file_size?: number;
+    analysis_depth?: 'basic' | 'standard' | 'deep';
     file_paths?: string[];
     rule_set_id?: string;
     prompt_template_id?: string;


### PR DESCRIPTION
## User description

在对git项目进行“快速审计”时，实际rule_set_id、prompt_template_id这两个参数是没有传入的，导致快速审计时始终无法使用自定义的规则集和提示词模版，需要在前后端加上对应的接口参数。

<img width="880" height="776" alt="企业微信截图_74e6f1e8-283b-4d93-81f0-c71c0af43067" src="https://github.com/user-attachments/assets/5a4bb9d6-e6a8-45a0-a2d5-6acd1c397539" />


## PR Type
Bug fix

## Description

- index.ts中完善对CreateAuditTaskForm结构的定义
- database.ts中添加对createAuditTask函数参数的解析
- projects.py中重新构建user_config['scan_config']