### PR TITLE
docs: replace raw URLs with jsDelivr CDN

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,7 +257,7 @@ curl -fsSL https://raw.githubusercontent.com/lintsinghua/DeepAudit/v3.0.0/docker
 
 ```bash
 # 国内加速版 - 使用南京大学 GHCR 镜像站
-curl -fsSL https://raw.githubusercontent.com/lintsinghua/DeepAudit/v3.0.0/docker-compose.prod.cn.yml | docker compose -f - up -d
+curl -fsSL https://fastly.jsdelivr.net/gh/lintsinghua/DeepAudit/docker-compose.prod.cn.yml | docker compose -f - up -d
 ```
 <details>
 <summary>手动拉取镜像（如需单独拉取）（点击展开）</summary>


### PR DESCRIPTION
将 README 中的 raw 链接替换为 jsDelivr 加速地址，提升国内访问速度。