### PR TITLE
fix: 修复 file_path 始终为 null 的问题

### DIFF
--- a/backend/alembic/versions/009_add_verdict_to_agent_findings.py
+++ b/backend/alembic/versions/009_add_verdict_to_agent_findings.py
@@ -18,7 +18,9 @@ depends_on = None
 
 def upgrade() -> None:
     op.add_column('agent_findings', sa.Column('verdict', sa.String(length=30), nullable=True))
+    op.create_index('ix_agent_findings_verdict', 'agent_findings', ['verdict'])
 
 
 def downgrade() -> None:
+    op.drop_index('ix_agent_findings_verdict', table_name='agent_findings')
     op.drop_column('agent_findings', 'verdict')

--- a/backend/alembic/versions/009_add_verdict_to_agent_findings.py
+++ b/backend/alembic/versions/009_add_verdict_to_agent_findings.py
@@ -1,0 +1,24 @@
+"""Add verdict column to agent_findings
+
+Revision ID: 009_add_verdict_to_agent_findings
+Revises: 008_add_files_with_findings
+Create Date: 2026-05-04
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '009_add_verdict_to_agent_findings'
+down_revision = '008_add_files_with_findings'
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column('agent_findings', sa.Column('verdict', sa.String(length=30), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column('agent_findings', 'verdict')

--- a/backend/app/api/v1/endpoints/agent_tasks.py
+++ b/backend/app/api/v1/endpoints/agent_tasks.py
@@ -1264,8 +1264,16 @@ async def _save_findings(
             file_path = (
                 finding.get("file_path") or
                 finding.get("file") or
-                finding.get("location", "").split(":")[0] if ":" in finding.get("location", "") else finding.get("location")
+                (finding.get("location", "").split(":")[0] if ":" in finding.get("location", "") else finding.get("location", ""))
             )
+
+            # 🔥 v2.2: file_path 为空直接跳过
+            if not file_path or not file_path.strip():
+                logger.warning(
+                    f"[SaveFindings] 🚫 跳过无 file_path 的 finding: "
+                    f"title={finding.get('title', 'N/A')[:50]}, type={finding.get('vulnerability_type', '?')}"
+                )
+                continue
 
             # 🔥 v2.1: 文件路径验证 - 过滤幻觉发现
             if project_root and file_path:
@@ -1336,7 +1344,8 @@ async def _save_findings(
 
             # 🔥 Handle verification status
             is_verified = finding.get("is_verified", False)
-            if finding.get("verdict") == "confirmed":
+            verdict = finding.get("verdict")  # confirmed / likely / uncertain / false_positive
+            if verdict == "confirmed":
                 is_verified = True
 
             # 🔥 Handle PoC information
@@ -1381,6 +1390,7 @@ async def _save_findings(
                 code_snippet=code_snippet[:10000] if code_snippet else None,
                 suggestion=suggestion[:5000] if suggestion else None,
                 is_verified=is_verified,
+                verdict=verdict,  # 🔥 新增：保存 verdict 到数据库
                 ai_confidence=confidence,  # 🔥 FIX: Use ai_confidence, not confidence
                 status=FindingStatus.VERIFIED if is_verified else FindingStatus.NEW,
                 # 🔥 Additional fields

--- a/backend/app/api/v1/endpoints/agent_tasks.py
+++ b/backend/app/api/v1/endpoints/agent_tasks.py
@@ -567,35 +567,46 @@ async def _execute_agent_task(task_id: str):
                 # files_with_findings = 有漏洞发现的唯一文件数
                 task.analyzed_files = task.total_files  # Agent 扫描了所有符合条件的文件
 
-                files_with_findings_set = set()
+                # 🔥 FIX: 先过滤 findings，再用过滤后的列表做统计
+                # 与 _save_findings 的过滤逻辑保持一致（排除无 file_path 的 finding）
+                filtered_findings = []
                 for f in findings:
-                    if isinstance(f, dict):
-                        file_path = f.get("file_path") or f.get("file") or f.get("location", "").split(":")[0]
-                        if file_path:
-                            files_with_findings_set.add(file_path)
+                    if not isinstance(f, dict):
+                        continue
+                    fp = f.get("file_path") or f.get("file") or ""
+                    if not fp.strip() and f.get("location"):
+                        loc = f.get("location", "")
+                        fp = loc.split(":")[0] if ":" in loc else loc
+                    if fp and fp.strip():
+                        filtered_findings.append(f)
+
+                files_with_findings_set = set()
+                for f in filtered_findings:
+                    file_path = f.get("file_path") or f.get("file") or f.get("location", "").split(":")[0]
+                    if file_path:
+                        files_with_findings_set.add(file_path)
                 task.files_with_findings = len(files_with_findings_set)
 
-                # 统计严重程度和验证状态
+                # 统计严重程度和验证状态（使用过滤后的列表）
                 verified_count = 0
-                for f in findings:
-                    if isinstance(f, dict):
-                        sev = str(f.get("severity", "low")).lower()
-                        if sev == "critical":
-                            task.critical_count += 1
-                        elif sev == "high":
-                            task.high_count += 1
-                        elif sev == "medium":
-                            task.medium_count += 1
-                        elif sev == "low":
-                            task.low_count += 1
-                        # 🔥 统计已验证的发现
-                        if f.get("is_verified") or f.get("verdict") == "confirmed":
-                            verified_count += 1
+                for f in filtered_findings:
+                    sev = str(f.get("severity", "low")).lower()
+                    if sev == "critical":
+                        task.critical_count += 1
+                    elif sev == "high":
+                        task.high_count += 1
+                    elif sev == "medium":
+                        task.medium_count += 1
+                    elif sev == "low":
+                        task.low_count += 1
+                    # 🔥 统计已验证的发现
+                    if f.get("is_verified") or f.get("verdict") == "confirmed":
+                        verified_count += 1
                 task.verified_count = verified_count
                 
-                # 计算安全评分
-                task.security_score = _calculate_security_score(findings)
-                task.quality_score = _calculate_security_score(findings)
+                # 计算安全评分（使用过滤后的列表）
+                task.security_score = _calculate_security_score(filtered_findings)
+                task.quality_score = _calculate_security_score(filtered_findings)
                 # 🔥 注意: progress_percentage 是计算属性，不需要手动设置
                 # 当 status = COMPLETED 时会自动返回 100.0
                 
@@ -1262,10 +1273,12 @@ async def _save_findings(
                 type_enum = VulnerabilityType.DESERIALIZATION
 
             # 🔥 Handle file path (support multiple field names)
+            raw_location = finding.get("location")
+            location_str = raw_location if isinstance(raw_location, str) else ""
             file_path = (
                 finding.get("file_path") or
                 finding.get("file") or
-                (finding.get("location", "").split(":")[0] if ":" in finding.get("location", "") else finding.get("location", ""))
+                (location_str.split(":")[0] if ":" in location_str else location_str)
             )
 
             # 🔥 v2.2: file_path 为空直接跳过
@@ -1293,9 +1306,9 @@ async def _save_findings(
 
             # 🔥 Handle line numbers (support multiple formats)
             line_start = finding.get("line_start") or finding.get("line")
-            if not line_start and ":" in finding.get("location", ""):
+            if not line_start and ":" in location_str:
                 try:
-                    line_start = int(finding.get("location", "").split(":")[1])
+                    line_start = int(location_str.split(":")[1])
                 except (ValueError, IndexError):
                     line_start = None
 

--- a/backend/app/api/v1/endpoints/agent_tasks.py
+++ b/backend/app/api/v1/endpoints/agent_tasks.py
@@ -194,6 +194,7 @@ class AgentFindingResponse(BaseModel):
     status: str
     
     suggestion: Optional[str] = None
+    verdict: Optional[str] = None
     poc: Optional[dict] = None
     
     created_at: datetime

--- a/backend/app/api/v1/endpoints/agent_tasks.py
+++ b/backend/app/api/v1/endpoints/agent_tasks.py
@@ -570,6 +570,7 @@ async def _execute_agent_task(task_id: str):
                 # 🔥 FIX: 先过滤 findings，再用过滤后的列表做统计
                 # 与 _save_findings 的过滤逻辑保持一致（排除无 file_path 的 finding）
                 filtered_findings = []
+                files_with_findings_set = set()
                 for f in findings:
                     if isinstance(f, dict):
                         raw_file_path = f.get("file_path") or f.get("file")
@@ -580,6 +581,7 @@ async def _execute_agent_task(task_id: str):
                             file_path = location.split(":")[0]
                         if file_path:
                             files_with_findings_set.add(file_path)
+                            filtered_findings.append(f)
                 task.files_with_findings = len(files_with_findings_set)
 
                 # 统计严重程度和验证状态（使用过滤后的列表）

--- a/backend/app/api/v1/endpoints/agent_tasks.py
+++ b/backend/app/api/v1/endpoints/agent_tasks.py
@@ -571,20 +571,15 @@ async def _execute_agent_task(task_id: str):
                 # 与 _save_findings 的过滤逻辑保持一致（排除无 file_path 的 finding）
                 filtered_findings = []
                 for f in findings:
-                    if not isinstance(f, dict):
-                        continue
-                    fp = f.get("file_path") or f.get("file") or ""
-                    if not fp.strip() and f.get("location"):
-                        loc = f.get("location", "")
-                        fp = loc.split(":")[0] if ":" in loc else loc
-                    if fp and fp.strip():
-                        filtered_findings.append(f)
-
-                files_with_findings_set = set()
-                for f in filtered_findings:
-                    file_path = f.get("file_path") or f.get("file") or f.get("location", "").split(":")[0]
-                    if file_path:
-                        files_with_findings_set.add(file_path)
+                    if isinstance(f, dict):
+                        raw_file_path = f.get("file_path") or f.get("file")
+                        file_path = raw_file_path if isinstance(raw_file_path, str) else ""
+                        if not file_path:
+                            raw_location = f.get("location", "")
+                            location = raw_location if isinstance(raw_location, str) else ""
+                            file_path = location.split(":")[0]
+                        if file_path:
+                            files_with_findings_set.add(file_path)
                 task.files_with_findings = len(files_with_findings_set)
 
                 # 统计严重程度和验证状态（使用过滤后的列表）
@@ -1273,13 +1268,12 @@ async def _save_findings(
                 type_enum = VulnerabilityType.DESERIALIZATION
 
             # 🔥 Handle file path (support multiple field names)
-            raw_location = finding.get("location")
-            location_str = raw_location if isinstance(raw_location, str) else ""
-            file_path = (
-                finding.get("file_path") or
-                finding.get("file") or
-                (location_str.split(":")[0] if ":" in location_str else location_str)
-            )
+            raw_file_path = finding.get("file_path") or finding.get("file")
+            file_path = raw_file_path if isinstance(raw_file_path, str) else ""
+            if not file_path:
+                raw_location = finding.get("location", "")
+                location = raw_location if isinstance(raw_location, str) else ""
+                file_path = location.split(":")[0] if ":" in location else location
 
             # 🔥 v2.2: file_path 为空直接跳过
             if not file_path or not file_path.strip():
@@ -1306,9 +1300,11 @@ async def _save_findings(
 
             # 🔥 Handle line numbers (support multiple formats)
             line_start = finding.get("line_start") or finding.get("line")
-            if not line_start and ":" in location_str:
+            raw_location = finding.get("location", "")
+            location = raw_location if isinstance(raw_location, str) else ""
+            if not line_start and ":" in location:
                 try:
-                    line_start = int(location_str.split(":")[1])
+                    line_start = int(location.split(":")[1])
                 except (ValueError, IndexError):
                     line_start = None
 

--- a/backend/app/models/agent_task.py
+++ b/backend/app/models/agent_task.py
@@ -355,6 +355,7 @@ class AgentFinding(Base):
     
     # 验证信息
     status = Column(String(30), default=FindingStatus.NEW, index=True)
+    verdict = Column(String(30), nullable=True, index=True)  # confirmed / likely / uncertain / false_positive
     is_verified = Column(Boolean, default=False)
     verification_method = Column(Text, nullable=True)
     verification_result = Column(JSON, nullable=True)

--- a/backend/app/services/agent/agents/analysis.py
+++ b/backend/app/services/agent/agents/analysis.py
@@ -771,7 +771,15 @@ Final Answer:""",
                 file_path = finding.get("file_path") or finding.get("file") or ""
                 if not file_path.strip() and finding.get("location"):
                     loc = finding.get("location", "")
-                    file_path = loc.split(":")[0] if ":" in loc else loc
+                    if isinstance(loc, str):
+                        file_path = loc.split(":")[0] if ":" in loc else loc
+                    else:
+                        # location 是非字符串类型（dict/list 等），跳过
+                        logger.warning(
+                            f"[Analysis] 🚫 跳过 location 非字符串的 finding: "
+                            f"location type={type(loc).__name__}, title={finding.get('title', '?')[:50]}"
+                        )
+                        continue
                 if not file_path.strip():
                     skipped_no_filepath += 1
                     logger.warning(

--- a/backend/app/services/agent/agents/analysis.py
+++ b/backend/app/services/agent/agents/analysis.py
@@ -759,10 +759,21 @@ Final Answer:""",
             # 标准化发现
             logger.info(f"[{self.name}] Standardizing {len(all_findings)} findings")
             standardized_findings = []
+            skipped_no_filepath = 0
             for finding in all_findings:
                 # 确保 finding 是字典
                 if not isinstance(finding, dict):
                     logger.warning(f"Skipping invalid finding (not a dict): {finding}")
+                    continue
+                
+                # 🔥 v2.2: file_path 必填校验 - 没有 file_path 的 finding 直接拒绝
+                file_path = finding.get("file_path", "") or ""
+                if not file_path.strip():
+                    skipped_no_filepath += 1
+                    logger.warning(
+                        f"[Analysis] 🚫 跳过无 file_path 的 finding: "
+                        f"title={finding.get('title', '?')[:50]}, type={finding.get('vulnerability_type', '?')}"
+                    )
                     continue
                     
                 standardized = {
@@ -770,7 +781,7 @@ Final Answer:""",
                     "severity": finding.get("severity", "medium"),
                     "title": finding.get("title", "Unknown Finding"),
                     "description": finding.get("description", ""),
-                    "file_path": finding.get("file_path", ""),
+                    "file_path": file_path,
                     "line_start": finding.get("line_start") or finding.get("line", 0),
                     "code_snippet": finding.get("code_snippet", ""),
                     "source": finding.get("source", ""),
@@ -780,6 +791,12 @@ Final Answer:""",
                     "needs_verification": finding.get("needs_verification", True),
                 }
                 standardized_findings.append(standardized)
+            
+            if skipped_no_filepath > 0:
+                logger.warning(
+                    f"[Analysis] ⚠️ 跳过了 {skipped_no_filepath} 个无 file_path 的 findings，"
+                    f"保留 {len(standardized_findings)} 个有效 findings"
+                )
             
             await self.emit_event(
                 "info",

--- a/backend/app/services/agent/agents/analysis.py
+++ b/backend/app/services/agent/agents/analysis.py
@@ -767,7 +767,11 @@ Final Answer:""",
                     continue
                 
                 # 🔥 v2.2: file_path 必填校验 - 没有 file_path 的 finding 直接拒绝
-                file_path = finding.get("file_path", "") or ""
+                # 优先从 file_path 获取，fallback 到 file / location
+                file_path = finding.get("file_path") or finding.get("file") or ""
+                if not file_path.strip() and finding.get("location"):
+                    loc = finding.get("location", "")
+                    file_path = loc.split(":")[0] if ":" in loc else loc
                 if not file_path.strip():
                     skipped_no_filepath += 1
                     logger.warning(

--- a/backend/app/services/agent/agents/orchestrator.py
+++ b/backend/app/services/agent/agents/orchestrator.py
@@ -878,10 +878,11 @@ Action Input: {{"参数": "值"}}
                                 potential_file = parts[0].strip()
                                 # 只有当 parts[0] 看起来像文件路径时才提取
                                 # 文件路径通常包含 . 且没有空格（或只在结尾有扩展名）
+                                # 🔥 FIX: 放宽文件路径校验 - 不再限制扩展名，只要像文件路径就提取
                                 if ("." in potential_file and
                                     " " not in potential_file and
                                     len(potential_file) < 100 and
-                                    any(potential_file.endswith(ext) for ext in ['.py', '.js', '.ts', '.java', '.go', '.php', '.rb', '.c', '.cpp', '.h'])):
+                                    not potential_file.endswith("/")):
                                     file_path = potential_file
                                     # 尝试提取行号
                                     if len(parts) > 1:
@@ -962,7 +963,28 @@ Action Input: {{"参数": "值"}}
                                 (new_type in existing_type) or (existing_type in new_type)
                             )
 
+                            # 🔥 Match criteria for same-file findings
                             if same_file and (same_line or similar_desc or same_type):
+                                match_found = True
+                            elif same_type and same_line and not same_file:
+                                # 🔥 FIX: Only allow cross-file matching when:
+                                # 1. new_file is garbage ("?"/empty) - verification returned bad path
+                                # 2. One path is a prefix of the other ("src/foo.py" vs "foo.py")
+                                # Do NOT merge when existing_file is garbage - that would lose the real path.
+                                new_is_garbage = not new_file or new_file == "?"
+                                prefix_match = (
+                                    new_file.endswith("/" + existing_file) or
+                                    existing_file.endswith("/" + new_file)
+                                )
+                                if new_is_garbage or prefix_match:
+                                    match_found = True
+                                    logger.info(f"[Orchestrator] Matched by type+line despite file mismatch: {new_file} vs {existing_file}")
+                                else:
+                                    match_found = False
+                            else:
+                                match_found = False
+
+                            if match_found:
                                 # Update existing with new info (e.g. verification results)
                                 # 🔥 FIX: Smart merge - don't overwrite good data with empty values
                                 merged = dict(existing_f)  # Start with existing data

--- a/backend/app/services/agent/agents/orchestrator.py
+++ b/backend/app/services/agent/agents/orchestrator.py
@@ -970,7 +970,7 @@ Action Input: {{"参数": "值"}}
                                 match_found = True
                             elif same_type and same_line and not same_file:
                                 # 🔥 FIX: Only allow cross-file matching when:
-                                # 1. new_file is garbage ("?"/empty) - verification returned bad path
+                                # 1. new_file is garbage ("?"/empty) and descriptions still match
                                 # 2. One path is a prefix of the other ("src/foo.py" vs "foo.py")
                                 # Do NOT merge when existing_file is garbage - that would lose the real path.
                                 new_is_garbage = not new_file or new_file == "?"
@@ -978,7 +978,7 @@ Action Input: {{"参数": "值"}}
                                     new_file.endswith("/" + existing_file) or
                                     existing_file.endswith("/" + new_file)
                                 )
-                                if new_is_garbage or prefix_match:
+                                if (new_is_garbage and similar_desc) or prefix_match:
                                     match_found = True
                                     logger.info(f"[Orchestrator] Matched by type+line despite file mismatch: {new_file} vs {existing_file}")
                                 else:

--- a/backend/app/services/agent/agents/orchestrator.py
+++ b/backend/app/services/agent/agents/orchestrator.py
@@ -933,6 +933,8 @@ Action Input: {{"参数": "值"}}
                     for new_f in valid_findings:
                         # Normalize the finding first
                         normalized_new = self._normalize_finding(new_f)
+                        if not normalized_new:
+                            continue
 
                         # Create fingerprint for deduplication (file + description similarity)
                         new_file = normalized_new.get("file_path", "").lower().strip()


### PR DESCRIPTION
## 根因分析

本 PR 修复了 Agent 审计任务中 findings 的  字段始终为 null 的问题，该问题导致前端无法定位漏洞文件位置。

### Bug 1：三元表达式运算符优先级错误
 中从  字段提取文件路径时，三元表达式缺少括号：
```python
# 修复前（错误）：Python 运算符优先级导致整个表达式被解析为条件表达式的 body
finding.get('location', '').split(':')[0] if ':' in finding.get('location', '') else finding.get('location')

# 修复后（正确）：加括号明确优先级
(finding.get('location', '').split(':')[0] if ':' in finding.get('location', '') else finding.get('location', ''))
```

### Bug 2：无 file_path 的 findings 直接入库
LLM 有时返回不含  的 findings，这些无效数据直接写入数据库。

### Bug 3：orchestrator 文件扩展名白名单过严
只允许 ，漏掉  等配置文件。

### Bug 4：merge 逻辑未考虑 garbage path
当 new_file 为无效值（如 `?`）时，仍可能覆盖 existing 的有效路径。

## 修复内容

| 文件 | 改动 |
|------|------|
|  | 三元表达式加括号 + file_path 空值跳过 + verdict 字段保存 |
|  | 放宽扩展名校验 + garbage path 不参与 merge |
|  | AgentFinding 模型新增  列 |
|  | _standardize_findings 新增 file_path 必填校验 |

## 验证
- [ ] 本地测试通过
- [ ] 数据库 migration 需执行（新增 verdict 列）