### PR TITLE
fix: 修复 DeepSeek V4 Pro 推理模型 content 为空的问题

### DIFF
--- a/backend/app/services/agent/agents/base.py
+++ b/backend/app/services/agent/agents/base.py
@@ -1044,6 +1044,10 @@ class BaseAgent(ABC):
                         # 🔥 CRITICAL: 让出控制权给事件循环，让 SSE 有机会发送事件
                         await asyncio.sleep(0)
 
+                    elif chunk["type"] == "keepalive":
+                        first_token_received = True
+                        last_activity = time.time()
+
                     elif chunk["type"] == "done":
                         accumulated = chunk["content"]
                         if chunk.get("usage"):
@@ -1052,7 +1056,7 @@ class BaseAgent(ABC):
                         reasoning = chunk.get("reasoning_content", "")
                         reasoning_tokens_est = chunk.get("reasoning_tokens", 0)
                         if reasoning:
-                            logger.info(f"[{self.name}] reasoning_content: {len(reasoning)} chars, ~{reasoning_tokens_est} tokens")
+                            logger.debug(f"[{self.name}] reasoning_content: {len(reasoning)} chars, ~{reasoning_tokens_est} tokens")
                         break
 
                     elif chunk["type"] == "error":

--- a/backend/app/services/agent/agents/base.py
+++ b/backend/app/services/agent/agents/base.py
@@ -1048,6 +1048,11 @@ class BaseAgent(ABC):
                         accumulated = chunk["content"]
                         if chunk.get("usage"):
                             total_tokens = chunk["usage"].get("total_tokens", 0)
+                        # 🔥 记录推理模型的 reasoning 统计
+                        reasoning = chunk.get("reasoning_content", "")
+                        reasoning_tokens_est = chunk.get("reasoning_tokens", 0)
+                        if reasoning:
+                            logger.info(f"[{self.name}] reasoning_content: {len(reasoning)} chars, ~{reasoning_tokens_est} tokens")
                         break
 
                     elif chunk["type"] == "error":

--- a/backend/app/services/llm/adapters/litellm_adapter.py
+++ b/backend/app/services/llm/adapters/litellm_adapter.py
@@ -293,11 +293,30 @@ class LiteLLMAdapter(BaseLLMAdapter):
                     total_input_tokens=response.usage.prompt_tokens or 0,
                 )
 
+        # 🔥 提取 reasoning_content（推理模型如 DeepSeek V4 Pro 会在该字段输出推理过程）
+        reasoning_content = ""
+        if hasattr(choice.message, "reasoning_content") and choice.message.reasoning_content:
+            reasoning_content = choice.message.reasoning_content
+        elif hasattr(choice.message, "__dict__"):
+            reasoning_content = choice.message.__dict__.get("reasoning_content", "") or ""
+
+        reasoning_tokens = len(reasoning_content) // 2 if reasoning_content else 0  # 粗估
+        if reasoning_content:
+            logger.info(f"[reasoning] model={response.model}, reasoning_chars={len(reasoning_content)}, est_tokens={reasoning_tokens}")
+
+        # 🔥 FALLBACK: 推理模型（DeepSeek V4 Pro 等）可能将全部输出放在 reasoning_content，content 为空
+        final_content = choice.message.content or ""
+        if not final_content.strip() and reasoning_content.strip():
+            logger.warning(f"[reasoning-fallback] model={response.model}, content empty, falling back to reasoning_content ({len(reasoning_content)} chars)")
+            final_content = reasoning_content
+
         return LLMResponse(
-            content=choice.message.content or "",
+            content=final_content,
             model=response.model,
             usage=usage,
             finish_reason=choice.finish_reason,
+            reasoning_content=reasoning_content,
+            reasoning_tokens=reasoning_tokens,
         )
 
     async def stream_complete(self, request: LLMRequest):
@@ -347,6 +366,7 @@ class LiteLLMAdapter(BaseLLMAdapter):
         kwargs["timeout"] = self.config.timeout
 
         accumulated_content = ""
+        accumulated_reasoning = ""  # 🔥 累积推理内容
         final_usage = None  # 🔥 存储最终的 usage 信息
         chunk_count = 0  # 🔥 跟踪 chunk 数量
 
@@ -371,7 +391,12 @@ class LiteLLMAdapter(BaseLLMAdapter):
 
                 delta = chunk.choices[0].delta
                 content = getattr(delta, "content", "") or ""
+                # 🔥 提取 reasoning_content（推理模型如 DeepSeek V4 Pro）
+                reasoning = getattr(delta, "reasoning_content", "") or ""
                 finish_reason = chunk.choices[0].finish_reason
+
+                if reasoning:
+                    accumulated_reasoning += reasoning
 
                 if content:
                     accumulated_content += content
@@ -397,19 +422,33 @@ class LiteLLMAdapter(BaseLLMAdapter):
                         }
                         logger.debug(f"Estimated usage: {final_usage}")
 
-                    # 🔥 ENHANCED: 如果累积内容为空但有 finish_reason，记录警告
-                    if not accumulated_content:
+                    # 🔥 FALLBACK: 推理模型可能将全部输出放在 reasoning_content，content 为空
+                    if not accumulated_content.strip() and accumulated_reasoning.strip():
+                        logger.warning(f"[reasoning-fallback-stream] model={self.config.model}, content empty after {chunk_count} chunks, falling back to reasoning_content ({len(accumulated_reasoning)} chars)")
+                        accumulated_content = accumulated_reasoning
+                    elif not accumulated_content:
                         logger.warning(f"Stream completed with no content after {chunk_count} chunks, finish_reason={finish_reason}")
+
+                    # 🔥 记录推理内容长度
+                    reasoning_tokens_est = len(accumulated_reasoning) // 2 if accumulated_reasoning else 0
+                    if accumulated_reasoning:
+                        logger.info(f"[reasoning-stream] model={self.config.model}, reasoning_chars={len(accumulated_reasoning)}, est_tokens={reasoning_tokens_est}")
 
                     yield {
                         "type": "done",
                         "content": accumulated_content,
                         "usage": final_usage,
                         "finish_reason": finish_reason,
+                        "reasoning_content": accumulated_reasoning,
+                        "reasoning_tokens": reasoning_tokens_est,
                     }
                     break
 
             # 🔥 ENHANCED: 如果循环结束但没有收到 finish_reason，也需要返回 done
+            # 🔥 FALLBACK: 推理模型 content 为空时回退到 reasoning_content
+            if not accumulated_content.strip() and accumulated_reasoning.strip():
+                logger.warning(f"[reasoning-fallback-stream] model={self.config.model}, stream ended without finish_reason, falling back to reasoning_content ({len(accumulated_reasoning)} chars)")
+                accumulated_content = accumulated_reasoning
             if accumulated_content:
                 logger.warning(f"Stream ended without finish_reason, returning accumulated content ({len(accumulated_content)} chars)")
                 if not final_usage:
@@ -421,11 +460,16 @@ class LiteLLMAdapter(BaseLLMAdapter):
                         "completion_tokens": output_tokens_estimate,
                         "total_tokens": input_tokens_estimate + output_tokens_estimate,
                     }
+                reasoning_tokens_est = len(accumulated_reasoning) // 2 if accumulated_reasoning else 0
+                if accumulated_reasoning:
+                    logger.info(f"[reasoning-stream] model={self.config.model}, reasoning_chars={len(accumulated_reasoning)}, est_tokens={reasoning_tokens_est}")
                 yield {
                     "type": "done",
                     "content": accumulated_content,
                     "usage": final_usage,
                     "finish_reason": "complete",
+                    "reasoning_content": accumulated_reasoning,
+                    "reasoning_tokens": reasoning_tokens_est,
                 }
 
         except litellm.exceptions.RateLimitError as e:

--- a/backend/app/services/llm/adapters/litellm_adapter.py
+++ b/backend/app/services/llm/adapters/litellm_adapter.py
@@ -307,7 +307,7 @@ class LiteLLMAdapter(BaseLLMAdapter):
         # 🔥 FALLBACK: 推理模型（DeepSeek V4 Pro 等）可能将全部输出放在 reasoning_content，content 为空
         final_content = choice.message.content or ""
         if not final_content.strip() and reasoning_content.strip():
-            logger.warning(f"[reasoning-fallback] model={response.model}, content empty, falling back to reasoning_content ({len(reasoning_content)} chars)")
+            logger.info(f"[reasoning-fallback] model={response.model}, content empty, falling back to reasoning_content ({len(reasoning_content)} chars)")
             final_content = reasoning_content
 
         return LLMResponse(
@@ -410,7 +410,15 @@ class LiteLLMAdapter(BaseLLMAdapter):
 
                 if finish_reason:
                     # 流式完成
-                    # 🔥 如果没有从 chunk 获取到 usage，进行估算
+                    # 🔥 FALLBACK: 推理模型可能将全部输出放在 reasoning_content，content 为空
+                    # 必须在 token 估算之前执行，确保估算基于最终 content
+                    if not accumulated_content.strip() and accumulated_reasoning.strip():
+                        logger.info(f"[reasoning-fallback-stream] model={self.config.model}, content empty after {chunk_count} chunks, falling back to reasoning_content ({len(accumulated_reasoning)} chars)")
+                        accumulated_content = accumulated_reasoning
+                    elif not accumulated_content:
+                        logger.warning(f"Stream completed with no content after {chunk_count} chunks, finish_reason={finish_reason}")
+
+                    # 🔥 如果没有从 chunk 获取到 usage，进行估算（基于最终 content）
                     if not final_usage:
                         output_tokens_estimate = estimate_tokens(
                             accumulated_content, self.config.model
@@ -421,13 +429,6 @@ class LiteLLMAdapter(BaseLLMAdapter):
                             "total_tokens": input_tokens_estimate + output_tokens_estimate,
                         }
                         logger.debug(f"Estimated usage: {final_usage}")
-
-                    # 🔥 FALLBACK: 推理模型可能将全部输出放在 reasoning_content，content 为空
-                    if not accumulated_content.strip() and accumulated_reasoning.strip():
-                        logger.warning(f"[reasoning-fallback-stream] model={self.config.model}, content empty after {chunk_count} chunks, falling back to reasoning_content ({len(accumulated_reasoning)} chars)")
-                        accumulated_content = accumulated_reasoning
-                    elif not accumulated_content:
-                        logger.warning(f"Stream completed with no content after {chunk_count} chunks, finish_reason={finish_reason}")
 
                     # 🔥 记录推理内容长度
                     reasoning_tokens_est = len(accumulated_reasoning) // 2 if accumulated_reasoning else 0
@@ -446,8 +447,9 @@ class LiteLLMAdapter(BaseLLMAdapter):
 
             # 🔥 ENHANCED: 如果循环结束但没有收到 finish_reason，也需要返回 done
             # 🔥 FALLBACK: 推理模型 content 为空时回退到 reasoning_content
+            # 必须在 token 估算之前执行，确保估算基于最终 content
             if not accumulated_content.strip() and accumulated_reasoning.strip():
-                logger.warning(f"[reasoning-fallback-stream] model={self.config.model}, stream ended without finish_reason, falling back to reasoning_content ({len(accumulated_reasoning)} chars)")
+                logger.info(f"[reasoning-fallback-stream] model={self.config.model}, stream ended without finish_reason, falling back to reasoning_content ({len(accumulated_reasoning)} chars)")
                 accumulated_content = accumulated_reasoning
             if accumulated_content:
                 logger.warning(f"Stream ended without finish_reason, returning accumulated content ({len(accumulated_content)} chars)")

--- a/backend/app/services/llm/adapters/litellm_adapter.py
+++ b/backend/app/services/llm/adapters/litellm_adapter.py
@@ -413,6 +413,8 @@ class LiteLLMAdapter(BaseLLMAdapter):
                         "content": content,
                         "accumulated": accumulated_content,
                     }
+                elif reasoning and not finish_reason:
+                    yield {"type": "keepalive"}
                 # 🔥 ENHANCED: 处理没有 content 但也没有 finish_reason 的情况
                 # 某些模型（如智谱 GLM）可能在某些 chunk 中不返回内容
 

--- a/backend/app/services/llm/adapters/litellm_adapter.py
+++ b/backend/app/services/llm/adapters/litellm_adapter.py
@@ -300,14 +300,14 @@ class LiteLLMAdapter(BaseLLMAdapter):
         elif hasattr(choice.message, "__dict__"):
             reasoning_content = choice.message.__dict__.get("reasoning_content", "") or ""
 
-        reasoning_tokens = len(reasoning_content) // 2 if reasoning_content else 0  # 粗估
+        reasoning_tokens = estimate_tokens(reasoning_content, self.config.model) if reasoning_content else 0
         if reasoning_content:
-            logger.info(f"[reasoning] model={response.model}, reasoning_chars={len(reasoning_content)}, est_tokens={reasoning_tokens}")
+            logger.debug(f"[reasoning] model={response.model}, reasoning_chars={len(reasoning_content)}, est_tokens={reasoning_tokens}")
 
         # 🔥 FALLBACK: 推理模型（DeepSeek V4 Pro 等）可能将全部输出放在 reasoning_content，content 为空
         final_content = choice.message.content or ""
         if not final_content.strip() and reasoning_content.strip():
-            logger.info(f"[reasoning-fallback] model={response.model}, content empty, falling back to reasoning_content ({len(reasoning_content)} chars)")
+            logger.debug(f"[reasoning-fallback] model={response.model}, content empty, falling back to reasoning_content ({len(reasoning_content)} chars)")
             final_content = reasoning_content
 
         return LLMResponse(
@@ -397,6 +397,14 @@ class LiteLLMAdapter(BaseLLMAdapter):
 
                 if reasoning:
                     accumulated_reasoning += reasoning
+                    # Yield a keepalive chunk so downstream knows the stream is active
+                    # (reasoning-only models would otherwise cause a first-token timeout)
+                    if not content:
+                        yield {
+                            "type": "token",
+                            "content": "",
+                            "accumulated": accumulated_content,
+                        }
 
                 if content:
                     accumulated_content += content
@@ -413,7 +421,7 @@ class LiteLLMAdapter(BaseLLMAdapter):
                     # 🔥 FALLBACK: 推理模型可能将全部输出放在 reasoning_content，content 为空
                     # 必须在 token 估算之前执行，确保估算基于最终 content
                     if not accumulated_content.strip() and accumulated_reasoning.strip():
-                        logger.info(f"[reasoning-fallback-stream] model={self.config.model}, content empty after {chunk_count} chunks, falling back to reasoning_content ({len(accumulated_reasoning)} chars)")
+                        logger.debug(f"[reasoning-fallback-stream] model={self.config.model}, content empty after {chunk_count} chunks, falling back to reasoning_content ({len(accumulated_reasoning)} chars)")
                         accumulated_content = accumulated_reasoning
                     elif not accumulated_content:
                         logger.warning(f"Stream completed with no content after {chunk_count} chunks, finish_reason={finish_reason}")
@@ -431,9 +439,9 @@ class LiteLLMAdapter(BaseLLMAdapter):
                         logger.debug(f"Estimated usage: {final_usage}")
 
                     # 🔥 记录推理内容长度
-                    reasoning_tokens_est = len(accumulated_reasoning) // 2 if accumulated_reasoning else 0
+                    reasoning_tokens_est = estimate_tokens(accumulated_reasoning, self.config.model) if accumulated_reasoning else 0
                     if accumulated_reasoning:
-                        logger.info(f"[reasoning-stream] model={self.config.model}, reasoning_chars={len(accumulated_reasoning)}, est_tokens={reasoning_tokens_est}")
+                        logger.debug(f"[reasoning-stream] model={self.config.model}, reasoning_chars={len(accumulated_reasoning)}, est_tokens={reasoning_tokens_est}")
 
                     yield {
                         "type": "done",
@@ -449,7 +457,7 @@ class LiteLLMAdapter(BaseLLMAdapter):
             # 🔥 FALLBACK: 推理模型 content 为空时回退到 reasoning_content
             # 必须在 token 估算之前执行，确保估算基于最终 content
             if not accumulated_content.strip() and accumulated_reasoning.strip():
-                logger.info(f"[reasoning-fallback-stream] model={self.config.model}, stream ended without finish_reason, falling back to reasoning_content ({len(accumulated_reasoning)} chars)")
+                logger.debug(f"[reasoning-fallback-stream] model={self.config.model}, stream ended without finish_reason, falling back to reasoning_content ({len(accumulated_reasoning)} chars)")
                 accumulated_content = accumulated_reasoning
             if accumulated_content:
                 logger.warning(f"Stream ended without finish_reason, returning accumulated content ({len(accumulated_content)} chars)")
@@ -462,9 +470,9 @@ class LiteLLMAdapter(BaseLLMAdapter):
                         "completion_tokens": output_tokens_estimate,
                         "total_tokens": input_tokens_estimate + output_tokens_estimate,
                     }
-                reasoning_tokens_est = len(accumulated_reasoning) // 2 if accumulated_reasoning else 0
+                reasoning_tokens_est = estimate_tokens(accumulated_reasoning, self.config.model) if accumulated_reasoning else 0
                 if accumulated_reasoning:
-                    logger.info(f"[reasoning-stream] model={self.config.model}, reasoning_chars={len(accumulated_reasoning)}, est_tokens={reasoning_tokens_est}")
+                    logger.debug(f"[reasoning-stream] model={self.config.model}, reasoning_chars={len(accumulated_reasoning)}, est_tokens={reasoning_tokens_est}")
                 yield {
                     "type": "done",
                     "content": accumulated_content,

--- a/backend/app/services/llm/service.py
+++ b/backend/app/services/llm/service.py
@@ -390,8 +390,8 @@ Please analyze the following code:
             content = response.content
             
             # 记录 LLM 原始响应（用于调试）
-            logger.info(f"📥 LLM 原始响应长度: {len(content) if content else 0} 字符")
-            logger.info(f"📥 LLM 原始响应内容:\n{content}")
+            logger.debug(f"📥 LLM 原始响应长度: {len(content) if content else 0} 字符")
+            logger.debug(f"📥 LLM 原始响应内容:\n{content[:500]}..." if content and len(content) > 500 else f"📥 LLM 原始响应内容:\n{content}")
             
             # 检查响应内容是否为空
             if not content or not content.strip():

--- a/backend/app/services/llm/types.py
+++ b/backend/app/services/llm/types.py
@@ -70,6 +70,8 @@ class LLMResponse:
     model: Optional[str] = None
     usage: Optional[LLMUsage] = None
     finish_reason: Optional[str] = None
+    reasoning_content: Optional[str] = None
+    reasoning_tokens: int = 0
 
 
 class LLMError(Exception):


### PR DESCRIPTION
## 根因分析

DeepSeek V4 Pro 等推理模型会将推理过程放在 `reasoning_content` 字段，而 `content` 字段可能为空字符串。现有 LLM 适配器只读取 `content`，导致返回空结果，Agent 无法获取任何输出。

## 修复内容

### 1. LLMResponse 新增字段（types.py）
- `reasoning_content: Optional[str]` - 存储推理内容
- `reasoning_tokens: int` - 推理 token 估算值

### 2. 非流式路径 fallback（litellm_adapter.py）
- 提取 `reasoning_content`（兼容 `__dict__` 兜底）
- 当 `content` 为空且 `reasoning_content` 非空时，fallback 到 `reasoning_content`

### 3. 流式路径 fallback（litellm_adapter.py）
- 累积 `reasoning_content`（从 delta 中提取）
- done 事件：content 为空时 fallback
- 异常结束（无 finish_reason）：同上 fallback
- done 事件中携带 `reasoning_content` 和 `reasoning_tokens`

### 4. Agent base 统计日志（base.py）
- `stream_llm_call` 的 done 事件处理中，记录 reasoning 统计日志

## 兼容性
- 对非推理模型（如 GPT-4、Claude）无影响：`reasoning_content` 默认为空，fallback 不触发
- `LLMResponse` 新增字段有默认值，不破坏现有调用方